### PR TITLE
Use __dirname instead of 'cssify' to find the cssify package in the wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (fileName) {
         function () {
             var css = inputString.replace(/\"/g, "\\\"").replace(/\n/g, "\\\n");
 
-            var moduleBody = "var css = '" + css + "'; (require('cssify'))(css); module.exports = css;";
+            var moduleBody = "var css = '" + css + "'; (require("+JSON.stringify(__dirname)+"))(css); module.exports = css;";
 
             this.queue(moduleBody);
             this.queue(null);


### PR DESCRIPTION
Previously, cssify had to be installed at the "top-level" so that the `require()` added to each CSS file could find it. With this change, cssify can be installed as a dependency of some other module and still work correctly.

(My use-case is adding cssify as another transform to my Browserify-wrapping module, compilist: http://gigahard.mine.nu/hg/compilist/ )
