### PR TITLE
Use document.createStyleSheet when is possible.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,24 +1,32 @@
 module.exports = function (css) {
-  var head = document.getElementsByTagName('head')[0],
-      style = document.createElement('style');
-
-  style.type = 'text/css';
-
-  if (style.styleSheet) {
-    style.styleSheet.cssText = css;
+  if (document.createStyleSheet) {
+    document.createStyleSheet(css);
   } else {
-    style.appendChild(document.createTextNode(css));
-  }
+    var head = document.getElementsByTagName('head')[0],
+        style = document.createElement('style');
+
+    style.type = 'text/css';
   
-  head.appendChild(style);
+    if (style.styleSheet) {
+      style.styleSheet.cssText = css;
+    } else {
+      style.appendChild(document.createTextNode(css));
+    }
+    
+    head.appendChild(style); 
+  }
 };
 
 module.exports.byUrl = function(url) {
-  var head = document.getElementsByTagName('head')[0],
-      link = document.createElement('link');
+  if (document.createStyleSheet) {
+    document.createStyleSheet(url);
+  } else {
+    var head = document.getElementsByTagName('head')[0],
+        link = document.createElement('link');
 
-  link.rel = 'stylesheet';
-  link.href = url;
+    link.rel = 'stylesheet';
+    link.href = url;
   
-  head.appendChild(link);
+    head.appendChild(link); 
+  }
 };


### PR DESCRIPTION
There is a known bug in IE when create `<link>` tag on the fly. Use document.createStyleSheet when is possible.

More info: http://msdn.microsoft.com/en-us/library/ie/ms531194(v=vs.85).aspx
