### PR TITLE
createStyleSheet(css) => createStyleSheet().cssTxt = css;

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,7 +1,7 @@
 module.exports = function (css, customDocument) {
   var doc = customDocument || document;
   if (doc.createStyleSheet) {
-    doc.createStyleSheet(css);
+    doc.createStyleSheet().cssText = css;
   } else {
     var head = doc.getElementsByTagName('head')[0],
         style = doc.createElement('style');


### PR DESCRIPTION
Relating to #10 `doc.createStylesheet(css)` at best doesn't apply the style and at worst throws an exception.

This `createStylesheet` syntax is tested and working in IE7/8. :)
