### PR TITLE
Support injecting styles multiple times

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,23 +1,34 @@
-module.exports = function (css, customDocument) {
+function injectStyleTag(document, fileName, cb) {
+  var style = document.getElementById(fileName);
+
+  if (style) {
+    cb(style);
+  } else {
+    var head = document.getElementsByTagName('head')[0];
+
+    style = document.createElement('style');
+    style.id = fileName;
+    cb(style);
+    head.appendChild(style);
+  }
+
+  return style;
+}
+
+module.exports = function (css, customDocument, fileName) {
   var doc = customDocument || document;
   if (doc.createStyleSheet) {
     var sheet = doc.createStyleSheet()
     sheet.cssText = css;
     return sheet.ownerNode;
   } else {
-    var head = doc.getElementsByTagName('head')[0],
-        style = doc.createElement('style');
-
-    style.type = 'text/css';
-
-    if (style.styleSheet) {
-      style.styleSheet.cssText = css;
-    } else {
-      style.appendChild(doc.createTextNode(css));
-    }
-
-    head.appendChild(style);
-    return style;
+    return injectStyleTag(doc, fileName, function(style) {
+      if (style.styleSheet) {
+        style.styleSheet.cssText = css;
+      } else {
+        style.innerHTML = css;
+      }
+    });
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (fileName, options) {
             var stringifiedCss = JSON.stringify(inputString);
             var requirePath = path.relative(path.dirname(fileName), __dirname)
             var moduleBody = options['auto-inject']
-              ? "var css = " + stringifiedCss + "; (require("+JSON.stringify('./'+requirePath)+"))(css); module.exports = css;"
+              ? "var css = " + stringifiedCss + "; (require("+JSON.stringify('./'+requirePath)+"))(css, undefined, '" + fileName + "'); module.exports = css;"
               : "module.exports = " + stringifiedCss;
 
             this.queue(moduleBody);


### PR DESCRIPTION
It's needed when you're rebundling multiple times without reloading.
See https://github.com/AgentME/browserify-hmr.

So instead of creating `style` tag on every transformation it tries to find existing tag.