### PR TITLE
match default development scopeName as in `css-modules-require-hook`

### DIFF
--- a/lib/process-css.js
+++ b/lib/process-css.js
@@ -23,7 +23,7 @@ function generateDebugName (styleName, fileName) {
     .replace(/[\W_]+/g, '_')
     .replace(/^_|_$/g, '')
 
-  return '_' + sanitisedPath + '___' + styleName
+  return '_' + sanitisedPath + '__' + styleName
 }
 
 function wrapCss (fileName, css, options, map) {


### PR DESCRIPTION
`css-modules-require-hook` defaults in development to using [this scopeName](https://github.com/css-modules/postcss-modules-scope/blob/master/src/index.js#L165-L168).

pull request fixes render mismatch when doing "universal" / "isomorphic" React app.

```
Warning: React attempted to reuse markup in a container but the checksum was invalid. This generally means that you are using server rendering and the markup generated on the server was not what the client was expecting. React injected new markup to compensate which works but you have lost many of the benefits of server rendering. Instead, figure out why the markup being generated is different on the client or server:
 (client) ents_landing_index___container" data-rea
 (server) ents_landing_index__container" data-reac
```