### PR TITLE
Fix unescaped slash issues on Windows.

### DIFF
--- a/lib/process-css.js
+++ b/lib/process-css.js
@@ -32,6 +32,10 @@ function wrapCss (fileName, css, options, map) {
   var packagePath = path.join(__dirname, '..')
   var dirName = path.dirname(fileName)
   var requirePath = path.relative(dirName, packagePath)
+  
+  // On Windows, path.relative returns unescaped backslashes and 
+  // that causes cssify to not be findable.
+  requirePath = requirePath.replace(/\\/g, '/');
 
   var moduleSource = options['auto-inject']
     ? [


### PR DESCRIPTION
See issue #46.

`cssify` is totally broken on Windows because the Windows backslashes generated by path.relative are being dropped into the moduleSource unescaped and therefore are disappearing. The fix is to escape them or use unixy forward-slashes. I modified process-css.js trivially:

requirePath = requirePath.replace(/\/g, '/');
